### PR TITLE
Add support for audio captions

### DIFF
--- a/lib/speech_markdown/transpiler.ex
+++ b/lib/speech_markdown/transpiler.ex
@@ -41,7 +41,18 @@ defmodule SpeechMarkdown.Transpiler do
     end
   end
 
-  defp convert({:audio, src}, _variant) do
+  # https://cloud.google.com/text-to-speech/docs/ssml#audio
+  # "The contents may include a <desc> element in which case the text contents
+  # of that element are used for display."
+  defp convert({:audio, caption, src}, variant)
+       when is_binary(caption) and byte_size(caption) > 0 and variant != :alexa do
+    {:audio, [src: src],
+     [
+       {:desc, [], [ch(caption)]}
+     ]}
+  end
+
+  defp convert({:audio, _, src}, _variant) do
     {:audio, [src: src], []}
   end
 

--- a/lib/speech_markdown/validator.ex
+++ b/lib/speech_markdown/validator.ex
@@ -45,7 +45,7 @@ defmodule SpeechMarkdown.Validator do
     :ok
   end
 
-  defp validate_node({:audio, _}) do
+  defp validate_node({:audio, _, _}) do
     :ok
   end
 

--- a/test/speech_markdown/grammar_test.exs
+++ b/test/speech_markdown/grammar_test.exs
@@ -36,6 +36,8 @@ defmodule SpeechMarkdown.Grammar.Test do
 
     # audio
     assert {:ok, _} = parse("![\"http://audio.mp3\"]")
+    assert {:ok, _} = parse("!()[\"https://audio.mp3\"]")
+    assert {:ok, _} = parse("!(hello world)[\"http://audio.mp3\"]")
   end
 
   test "emphasized symbols" do

--- a/test/speech_markdown/normalizer_test.exs
+++ b/test/speech_markdown/normalizer_test.exs
@@ -1,5 +1,5 @@
 defmodule SpeechMarkdown.NormalizerTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   import SpeechMarkdown.Grammar
 

--- a/test/speech_markdown/sectionizer_test.exs
+++ b/test/speech_markdown/sectionizer_test.exs
@@ -1,5 +1,5 @@
 defmodule SpeechMarkdown.SectionizerTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   import SpeechMarkdown.Sectionizer
   import SpeechMarkdown.Grammar

--- a/test/speech_markdown/transpiler_test.exs
+++ b/test/speech_markdown/transpiler_test.exs
@@ -1,5 +1,5 @@
 defmodule SpeechMarkdown.TranspilerTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   import SpeechMarkdown.Transpiler
 

--- a/test/speech_markdown/validator_test.exs
+++ b/test/speech_markdown/validator_test.exs
@@ -1,5 +1,5 @@
 defmodule SpeechMarkdown.ValidatorTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   import SpeechMarkdown.Validator
   import SpeechMarkdown.Grammar

--- a/test/speech_markdown_test.exs
+++ b/test/speech_markdown_test.exs
@@ -1,5 +1,5 @@
 defmodule SpeechMarkdownTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   import SpeechMarkdown
   alias SpeechMarkdown.ParseError


### PR DESCRIPTION
Adds support for `!(optional caption)["url"]` syntax.

The caption currently doesn't show up the plaintext version (because there's also the possibility of doing:

```
<audio src="bla">
<desc>caption</desc>
fallback text
</audio>
```
> The contents of the <audio> element are optional and are used if the audio file cannot be played or if the output device does not support audio

Should the caption still be included in the plaintext version?

See: 
- https://github.com/speechmarkdown/speechmarkdown-js/pull/79
- https://github.com/speechmarkdown/speechmarkdown-test-files/pull/5
- https://github.com/speechmarkdown/docs-speechmarkdown-reference/pull/6